### PR TITLE
Use `clang` on Mac

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+if [ "$(uname)" == "Darwin" ];
+then
+    export CC=clang
+    export CXX=clang++
+
+    export MACOSX_VERSION_MIN=10.7
+    export CXXFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
+    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
+    export LINKFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
+    export LINKFLAGS="${LINKFLAGS} -stdlib=libc++ -std=c++11 -L${LIBRARY_PATH}"
+fi
+
 chmod +x configure
 
 ./configure --prefix=$PREFIX --enable-cxx


### PR DESCRIPTION
This ensures `clang` is used to build on Mac.
