### PR TITLE
Updated to 6.1.1 version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.1.0" %}
+{% set version = "6.1.1" %}
 
 package:
   name: gmp
@@ -6,11 +6,11 @@ package:
 
 source:
   fn: gmp-{{ version }}.tar.bz2
-  url: ftp://ftp.gnu.org/gnu/gmp/gmp-{{ version }}.tar.bz2
-  md5: 86ee6e54ebfc4a90b643a65e402c4048
+  url: https://gmplib.org/download/gmp/gmp-{{ version }}.tar.bz2
+  md5: 4c175f86e11eb32d8bf9872ca3a8e11d
 
 build:
-  number: 3
+  number: 0
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
I have also updated the download link due to the following warning on the official GMP site:

> Also, make sure to use https and not http or ftp for downloading GMP (or anything else!)
